### PR TITLE
[WIP, do not merge yet] Ecei player - loading spinner

### DIFF
--- a/dashboard/web/dashboard_v2_vue/package.json
+++ b/dashboard/web/dashboard_v2_vue/package.json
@@ -15,6 +15,7 @@
     "plotly.js-dist": "^1.53.0",
     "socket.io": "^2.3.0",
     "vue": "^2.6.11",
+    "vue-loading-overlay": "^3.4.2",
     "vue-router": "^3.1.6",
     "vue-slider-component": "^3.2.11",
     "vuex": "^3.1.3"

--- a/dashboard/web/dashboard_v2_vue/src/components/CollSelector.vue
+++ b/dashboard/web/dashboard_v2_vue/src/components/CollSelector.vue
@@ -2,13 +2,9 @@
   <div>
     <input v-model="coll_name" placeholder="ABCDEF" />
     <!--button v-on:click="query_collection">Query collection</button-->
-    <loading-overlay
-      :active="isLoading"
-      :is-full-page="fullPage"
-      :loader="loader"
-    >
+    <loading-overlay :active.sync="isLoading" :is-full-page="fullPage" :loader="icon">
       <div class="loader__container"></div>
-    </loading-overlay>
+    </loading-overlay >
     <button @click.prevent="query_collection">Query collection</button>
     <p>Collection name is {{ coll_name }}</p>
   </div>
@@ -21,13 +17,13 @@ const axios = require("axios").default;
 
 export default {
   name: "CollSelector",
-  data: function() {
+  data() {
     return {
       coll_name: "ABC123",
       run_config: "",
       isLoading: false,
-      fullPage: true,
-      loader: "dots"
+      fullPage: false,
+      icon: "dots"
     };
   },
   components: {
@@ -37,10 +33,10 @@ export default {
     query_collection: function() {
       console.log("starting query_location");
       this.isLoading = true;
-      //setTimeout(() => {
-      //  this.isLoading = false
-      //}, 5000);
-      var vm = this;
+      setTimeout(() => {
+        this.isLoading = false
+      }, 5000);
+      /*var vm = this;
       var request = "/dashboard/query_db?coll_name=" + vm.coll_name;
       axios.get(request).then(function(response) {
         console.log(response.data);
@@ -49,7 +45,7 @@ export default {
           "Back in query_collection: " + vm.$store.state.run_config.run_id
         );
       });
-      this.isLoading = false;
+      //this.isLoading = false;*/
       console.log("ended query_location");
     }
   }

--- a/dashboard/web/dashboard_v2_vue/src/components/CollSelector.vue
+++ b/dashboard/web/dashboard_v2_vue/src/components/CollSelector.vue
@@ -1,12 +1,22 @@
 <template>
   <div>
-    <input v-model="coll_name" placeholder="ABCDEF"/>
-    <button v-on:click="query_collection">Query collection</button>
+    <input v-model="coll_name" placeholder="ABCDEF" />
+    <!--button v-on:click="query_collection">Query collection</button-->
+    <loading-overlay
+      :active="isLoading"
+      :is-full-page="fullPage"
+      :loader="loader"
+    >
+      <div class="loader__container"></div>
+    </loading-overlay>
+    <button @click.prevent="query_collection">Query collection</button>
     <p>Collection name is {{ coll_name }}</p>
   </div>
 </template>
 
 <script>
+import Loading from "vue-loading-overlay";
+import "vue-loading-overlay/dist/vue-loading.css";
 const axios = require("axios").default;
 
 export default {
@@ -14,18 +24,33 @@ export default {
   data: function() {
     return {
       coll_name: "ABC123",
-      run_config: ""
+      run_config: "",
+      isLoading: false,
+      fullPage: true,
+      loader: "dots"
     };
+  },
+  components: {
+    Loading
   },
   methods: {
     query_collection: function() {
+      console.log("starting query_location");
+      this.isLoading = true;
+      //setTimeout(() => {
+      //  this.isLoading = false
+      //}, 5000);
       var vm = this;
       var request = "/dashboard/query_db?coll_name=" + vm.coll_name;
-      axios.get(request).then(function (response) {
+      axios.get(request).then(function(response) {
         console.log(response.data);
         vm.$store.dispatch("set_run_config", response.data);
-        console.log("Back in query_collection: " + vm.$store.state.run_config.run_id);
-      });      
+        console.log(
+          "Back in query_collection: " + vm.$store.state.run_config.run_id
+        );
+      });
+      this.isLoading = false;
+      console.log("ended query_location");
     }
   }
 };

--- a/dashboard/web/dashboard_v2_vue/src/main.js
+++ b/dashboard/web/dashboard_v2_vue/src/main.js
@@ -1,13 +1,19 @@
 import Vue from "vue";
 import App from "./App.vue";
 import store from "./store.js";
+import Loading from "vue-loading-overlay";
+import "vue-loading-overlay/dist/vue-loading.css";
+
+Vue.component("loading-overlay", Loading);
 
 Vue.config.productionTip = false;
 
 new Vue({
   store: store,
-  created: function () {
-    console.log("App is created. location: " + location.host + ", port:" + location.port);
+  created: function() {
+    console.log(
+      "App is created. location: " + location.host + ", port:" + location.port
+    );
   },
   render: h => h(App)
 }).$mount("#app");


### PR DESCRIPTION
This adds the vue-loading-overlay to add the ability to have a spinner or loader object while data is loading. Currently somewhat working, I have this as a test on the query_collection button, with the normal method blanked out and just a 5s timer (for testing). The page is dimmed, but for some reason the dot loader component doesn't appear. This isn't a show stopper, the dimmed webpage would be useable. But a couple updates before merge:

- [ ] Add loading overlay to the data loading button (where most time spent)
- [ ] Ensure webpage dims when the normal operation of query_location and data loading buttons are in (not just SetTimeout)
- [ ] Clean up, determine if import should be in each components/ file, or in main.js (just in main.js seems to not work as well).